### PR TITLE
Improve use syntax

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -23,5 +23,5 @@ xcopy /Y /I osprey.compiler\errors\messages.txt "%LIB%\osprey.compiler"
 if %ERRORLEVEL%==0 (
 	echo.
 	echo [!] Compiling ospc...
-	%OSPC% /libpath "%LIB%" /verbose /main osprey.compiler.main /out bin\ospc.ovm /name ospc /doc bin\ospc.ovm.json /formatjson ospc\ospc.osp
+	%OSPC% /libpath "%LIB%" /import osprey.compiler /verbose /main osprey.compiler.main /out bin\ospc.ovm /name ospc /doc bin\ospc.ovm.json /formatjson ospc\ospc.osp
 )

--- a/errorCodeGen/build.bat
+++ b/errorCodeGen/build.bat
@@ -3,4 +3,4 @@
 set OSPC="%OSP%\Osprey\bin\Release\Osprey.exe"
 set LIB=%OSP%\lib
 
-%OSPC% /libpath "%LIB%" /verbose /main osprey.errorCodeGen.main errorCodeGen.osp
+%OSPC% /libpath "%LIB%" /import osprey.compiler /verbose /main osprey.errorCodeGen.main errorCodeGen.osp

--- a/errorCodeGen/errorCodeGen.osp
+++ b/errorCodeGen/errorCodeGen.osp
@@ -1,7 +1,7 @@
-use namespace aves;
-use namespace io;
-use namespace osprey.compiler;
-use namespace osprey.compiler.parser;
+use aves;
+use io;
+use osprey.compiler;
+use osprey.compiler.parser;
 
 namespace osprey.errorCodeGen;
 

--- a/errorCodeGen/errorCodeGen.osp
+++ b/errorCodeGen/errorCodeGen.osp
@@ -1,5 +1,3 @@
-use osprey.compiler;
-
 use namespace aves;
 use namespace io;
 use namespace osprey.compiler;

--- a/ospc/main.osp
+++ b/ospc/main.osp
@@ -1,8 +1,8 @@
-use namespace aves;
-use namespace aves.reflection;
-use namespace osprey.compiler.parser;
-use namespace osprey.compiler.syntax;
-use namespace osprey.compiler.syntax.wrapped;
+use aves;
+use aves.reflection;
+use osprey.compiler.parser;
+use osprey.compiler.syntax;
+use osprey.compiler.syntax.wrapped;
 
 namespace osprey.compiler;
 

--- a/ospc/ospc.osp
+++ b/ospc/ospc.osp
@@ -1,2 +1,1 @@
-use osprey.compiler;
 use "main.osp";

--- a/osprey.compiler.tests/TestErrorManager.osp
+++ b/osprey.compiler.tests/TestErrorManager.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.tests;
 

--- a/osprey.compiler.tests/build.bat
+++ b/osprey.compiler.tests/build.bat
@@ -5,4 +5,4 @@ set OSPC="%OSP%\Osprey\bin\Release\Osprey.exe"
 rem Path to the library folder
 set LIB=%OSP%\lib
 
-%OSPC% /libpath "%LIB%" /main osprey.compiler.tests.main /out osprey.compiler.tests.ovm /verbose /r *.osp
+%OSPC% /libpath "%LIB%" /import osprey.compiler /import testing.unit /main osprey.compiler.tests.main /out osprey.compiler.tests.ovm /verbose /r *.osp

--- a/osprey.compiler.tests/osprey.compiler.tests.osp
+++ b/osprey.compiler.tests/osprey.compiler.tests.osp
@@ -1,6 +1,6 @@
-use namespace aves;
-use namespace aves.reflection; // for Module
-use namespace testing.unit;
+use aves;
+use aves.reflection; // for Module
+use testing.unit;
 
 namespace osprey.compiler.tests;
 

--- a/osprey.compiler.tests/osprey.compiler.tests.osp
+++ b/osprey.compiler.tests/osprey.compiler.tests.osp
@@ -1,6 +1,3 @@
-use osprey.compiler;
-use testing.unit;
-
 use namespace aves;
 use namespace aves.reflection; // for Module
 use namespace testing.unit;

--- a/osprey.compiler.tests/parser/LexerTests.osp
+++ b/osprey.compiler.tests/parser/LexerTests.osp
@@ -1,6 +1,6 @@
-use namespace aves;
-use namespace testing.unit;
-use namespace osprey.compiler.tests;
+use aves;
+use testing.unit;
+use osprey.compiler.tests;
 use TT = osprey.compiler.parser.TokenType; // For brevity in some long lists
 use CT = osprey.compiler.parser.ContextualType; // Also for brevity
 

--- a/osprey.compiler/SourceFile.osp
+++ b/osprey.compiler/SourceFile.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace io;
+use aves;
+use io;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/SourceLocation.osp
+++ b/osprey.compiler/SourceLocation.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/compiler/CompilerErrorManager.osp
+++ b/osprey.compiler/compiler/CompilerErrorManager.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/compiler/compiler.osp
+++ b/osprey.compiler/compiler/compiler.osp
@@ -16,7 +16,7 @@ use "CompilerErrorManager.osp";
 
 // We can't put osprey.compiler.Compiler in its own file, because of Windows.
 
-use namespace aves;
+use aves;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/errors/CompileTimeError.osp
+++ b/osprey.compiler/errors/CompileTimeError.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/errors/ErrorCode.base.osp
+++ b/osprey.compiler/errors/ErrorCode.base.osp
@@ -1,7 +1,7 @@
-use namespace aves;
-use namespace aves.reflection; // for Module
-use namespace io;
-use namespace osprey.compiler.parser;
+use aves;
+use aves.reflection; // for Module
+use io;
+use osprey.compiler.parser;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/errors/ErrorCode.osp
+++ b/osprey.compiler/errors/ErrorCode.osp
@@ -1,7 +1,7 @@
-use namespace aves;
-use namespace aves.reflection; // for Module
-use namespace io;
-use namespace osprey.compiler.parser;
+use aves;
+use aves.reflection; // for Module
+use io;
+use osprey.compiler.parser;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/errors/ErrorManager.osp
+++ b/osprey.compiler/errors/ErrorManager.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/errors/NameError.osp
+++ b/osprey.compiler/errors/NameError.osp
@@ -1,6 +1,6 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.parser;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/errors/ParseError.osp
+++ b/osprey.compiler/errors/ParseError.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/errors/Warning.osp
+++ b/osprey.compiler/errors/Warning.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler;
 

--- a/osprey.compiler/parser/ContextualType.osp
+++ b/osprey.compiler/parser/ContextualType.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/Lexer.osp
+++ b/osprey.compiler/parser/Lexer.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/LexerFlags.osp
+++ b/osprey.compiler/parser/LexerFlags.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/LexicalFacts.osp
+++ b/osprey.compiler/parser/LexicalFacts.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/Modifiers.osp
+++ b/osprey.compiler/parser/Modifiers.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/ParseFlags.osp
+++ b/osprey.compiler/parser/ParseFlags.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/ParserBase.osp
+++ b/osprey.compiler/parser/ParserBase.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/ParserErrorManager.osp
+++ b/osprey.compiler/parser/ParserErrorManager.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/Token.osp
+++ b/osprey.compiler/parser/Token.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/TokenType.osp
+++ b/osprey.compiler/parser/TokenType.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/parser/parser.osp
+++ b/osprey.compiler/parser/parser.osp
@@ -387,9 +387,14 @@ public inheritable Parser is ParserBase
 	{
 		/* Syntax:
 		 *   use-directive:
+		 *     use-namespace-directive
+		 *     use-file-directive
+		 *     use-alias-directive
+		 *   use-namespace-directive:
 		 *     'use' qualified-name ';'
+		 *   use-file-directive:
 		 *     'use' string-literal ';'
-		 *     'use' 'namespace' qualified-name ';'
+		 *   use-alias-directive:
 		 *     'use' identifier '=' qualified-name ';'
 		 */
 		var start = expectr(ref i, TokenType.\use);
@@ -405,9 +410,9 @@ public inheritable Parser is ParserBase
 
 		if accept(i, TokenType.identifier)
 		{
-			// UseModuleDirective or UseAliasDirective: if we find an '=' after
+			// UseNamespaceDirective or UseAliasDirective: if we find an '=' after
 			// the identifier, it must be a member alias; otherwise, we parse it
-			// as a UseModuleDirective.
+			// as a UseNamespaceDirective.
 			if accept(i + 1, TokenType.assign)
 			{
 				// UseAliasDirective
@@ -419,21 +424,14 @@ public inheritable Parser is ParserBase
 			}
 			else
 			{
-				// UseModuleDirective
+				// UseNamespaceDirective
 				var name = parseQualifiedName(ref i);
 				var end = expectr(ref i, TokenType.semicolon);
-				return new UseModuleDirective(getLocation(start, end), name);
+				return new UseNamespaceDirective(getLocation(start, end), name);
 			}
 		}
 
-		// UseNamespaceDirective
-		do
-		{
-			expectr(ref i, TokenType.\namespace);
-			var name = parseQualifiedName(ref i);
-			var end = expectr(ref i, TokenType.semicolon);
-			return new UseNamespaceDirective(getLocation(start, end), name);
-		};
+		fatalError(lex[i], ErrorCode.err_UnexpectedToken);
 	}
 
 	//<region: Member declarations>

--- a/osprey.compiler/parser/parser.osp
+++ b/osprey.compiler/parser/parser.osp
@@ -16,8 +16,8 @@ use "TokenType.osp";
 
 // We can't put osprey.compiler.Parser in its own file, because of Windows.
 
-use namespace aves;
-use namespace osprey.compiler.syntax;
+use aves;
+use osprey.compiler.syntax;
 
 namespace osprey.compiler.parser;
 

--- a/osprey.compiler/syntax/ArgumentList.osp
+++ b/osprey.compiler/syntax/ArgumentList.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/Document.osp
+++ b/osprey.compiler/syntax/Document.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/Expression.osp
+++ b/osprey.compiler/syntax/Expression.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/ExternBody.osp
+++ b/osprey.compiler/syntax/ExternBody.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/NodeList.osp
+++ b/osprey.compiler/syntax/NodeList.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/ParameterList.osp
+++ b/osprey.compiler/syntax/ParameterList.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/ParseNode.osp
+++ b/osprey.compiler/syntax/ParseNode.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/ParseTreeVisitor.osp
+++ b/osprey.compiler/syntax/ParseTreeVisitor.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/ParseTreeVisitor.osp
+++ b/osprey.compiler/syntax/ParseTreeVisitor.osp
@@ -19,8 +19,6 @@ public abstract class ParseTreeVisitor
 
 	public abstract visitUseFileDirective(directive, arg);
 
-	public abstract visitUseModuleDirective(directive, arg);
-
 	public abstract visitUseNamespaceDirective(directive, arg);
 
 	public abstract visitVersionSpecifier(version, arg);

--- a/osprey.compiler/syntax/ParseTreeWalker.osp
+++ b/osprey.compiler/syntax/ParseTreeWalker.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/ParseTreeWalker.osp
+++ b/osprey.compiler/syntax/ParseTreeWalker.osp
@@ -32,11 +32,6 @@ public abstract class ParseTreeWalker is ParseTreeVisitor
 		return null;
 	}
 
-	overridable override visitUseModuleDirective(directive, arg)
-	{
-		return null;
-	}
-
 	overridable override visitUseNamespaceDirective(directive, arg)
 	{
 		return null;

--- a/osprey.compiler/syntax/QualifiedName.osp
+++ b/osprey.compiler/syntax/QualifiedName.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/Statement.osp
+++ b/osprey.compiler/syntax/Statement.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/SyntaxList.osp
+++ b/osprey.compiler/syntax/SyntaxList.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/TypeName.osp
+++ b/osprey.compiler/syntax/TypeName.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/UseDirective.osp
+++ b/osprey.compiler/syntax/UseDirective.osp
@@ -32,26 +32,6 @@ public class UseFileDirective is UseDirective
 	}
 }
 
-public class UseModuleDirective is UseDirective
-{
-	public new(location, name)
-	{
-		new base(location);
-
-		this._name = name;
-	}
-
-	private _name;
-	/// Summary: Gets the {QualifiedName} of the module that is imported
-	///          by this directive.
-	public get name = _name;
-
-	override accept(visitor, arg)
-	{
-		return visitor.visitUseModuleDirective(this, arg);
-	}
-}
-
 public class UseNamespaceDirective is UseDirective
 {
 	public new(location, name)

--- a/osprey.compiler/syntax/UseDirective.osp
+++ b/osprey.compiler/syntax/UseDirective.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/enums.osp
+++ b/osprey.compiler/syntax/enums.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/helpers.osp
+++ b/osprey.compiler/syntax/helpers.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/nodes.declaration.osp
+++ b/osprey.compiler/syntax/nodes.declaration.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/nodes.expression.osp
+++ b/osprey.compiler/syntax/nodes.expression.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/nodes.statement.osp
+++ b/osprey.compiler/syntax/nodes.statement.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/syntax/syntax.osp
+++ b/osprey.compiler/syntax/syntax.osp
@@ -39,7 +39,7 @@ use "nodes.statement.osp";
 
 // We can't put osprey.compiler.syntax.Syntax in its own file, because of Windows.
 
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax;
 

--- a/osprey.compiler/wrappedTree/Document.osp
+++ b/osprey.compiler/wrappedTree/Document.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/Expression.osp
+++ b/osprey.compiler/wrappedTree/Expression.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/ExternBody.osp
+++ b/osprey.compiler/wrappedTree/ExternBody.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/ParseTreeWrapper.osp
+++ b/osprey.compiler/wrappedTree/ParseTreeWrapper.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/ParseTreeWrapper.osp
+++ b/osprey.compiler/wrappedTree/ParseTreeWrapper.osp
@@ -54,11 +54,6 @@ public class ParseTreeWrapper is ParseTreeVisitor
 		return new WrappedUseFileDirective(directive);
 	}
 
-	override visitUseModuleDirective(directive, arg)
-	{
-		return new WrappedUseModuleDirective(directive);
-	}
-
 	override visitUseNamespaceDirective(directive, arg)
 	{
 		return new WrappedUseNamespaceDirective(directive);

--- a/osprey.compiler/wrappedTree/Statement.osp
+++ b/osprey.compiler/wrappedTree/Statement.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/TypeName.osp
+++ b/osprey.compiler/wrappedTree/TypeName.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/UseDirective.osp
+++ b/osprey.compiler/wrappedTree/UseDirective.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/UseDirective.osp
+++ b/osprey.compiler/wrappedTree/UseDirective.osp
@@ -29,23 +29,6 @@ public class WrappedUseFileDirective is WrappedUseDirective
 	}
 }
 
-public class WrappedUseModuleDirective is WrappedUseDirective
-{
-	public new(wrappedNode)
-	{
-		new base(wrappedNode);
-	}
-
-	/// Summary: Gets the {QualifiedName} of the module that is imported
-	///          by this directive.
-	public get name = wrappedNode.name;
-
-	override accept(visitor, arg)
-	{
-		return visitor.visitUseModuleDirective(this, arg);
-	}
-}
-
 public class WrappedUseNamespaceDirective is WrappedUseDirective
 {
 	public new(wrappedNode)

--- a/osprey.compiler/wrappedTree/WrappedNode.osp
+++ b/osprey.compiler/wrappedTree/WrappedNode.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/WrappedTreeUpdater.osp
+++ b/osprey.compiler/wrappedTree/WrappedTreeUpdater.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/WrappedTreeUpdater.osp
+++ b/osprey.compiler/wrappedTree/WrappedTreeUpdater.osp
@@ -48,11 +48,6 @@ public abstract class WrappedTreeUpdater is WrappedTreeVisitor
 		return directive;
 	}
 
-	overridable override visitUseModuleDirective(directive, arg)
-	{
-		return directive;
-	}
-
 	overridable override visitUseNamespaceDirective(directive, arg)
 	{
 		return directive;

--- a/osprey.compiler/wrappedTree/WrappedTreeVisitor.osp
+++ b/osprey.compiler/wrappedTree/WrappedTreeVisitor.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/nodes.declaration.osp
+++ b/osprey.compiler/wrappedTree/nodes.declaration.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/nodes.expression.osp
+++ b/osprey.compiler/wrappedTree/nodes.expression.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax.wrapped;
 

--- a/osprey.compiler/wrappedTree/nodes.statement.osp
+++ b/osprey.compiler/wrappedTree/nodes.statement.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace osprey.compiler.parser;
+use aves;
+use osprey.compiler.parser;
 
 namespace osprey.compiler.syntax.wrapped;
 


### PR DESCRIPTION
The module import directive, 'use x;', is removed. Only '/import' can be used to import modules now. The purpose of this is to pave the way for better dependency management, in the shape of build files, which will be implemented in ospc.

At the same time, the namespace import directive, 'use namespace x;', is shortened to just 'use x;', which gets rid of one of Osprey's more annoying warts. The new syntax fits better into the language.

Needless to say, this change breaks an awful lot of code - in fact, just about all Osprey source files are now invalid! Hence, this PR also fixes syntax errors introduced by this change.